### PR TITLE
Fix rows height for the following document tabs

### DIFF
--- a/doorhole.py
+++ b/doorhole.py
@@ -349,6 +349,9 @@ class RequirementManager(QWidget):
 		self.view.horizontalHeader().setStretchLastSection(True)
 		self.view.setWordWrap(True)
 		self.view.resizeColumnsToContents()
+		#self.view.resizeRowsToContents() # this seems to work only for first document tab but is not resizing properly the following tabs
+		header = self.view.verticalHeader()
+		header.setSectionResizeMode(QHeaderView.ResizeToContents)
 		self.view.resizeRowsToContents()
 		self.view.setSelectionMode(QAbstractItemView.SingleSelection)
 		self.view.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel);


### PR DESCRIPTION
 - resizeColumnsToContents worked fine only on the first tab

Tested only on Win10.1909.x64 with Python 3.9.1, Doorstop v2.1.2, PySide2-5.15.2, Markdown 2.6.11.

![image](https://user-images.githubusercontent.com/4947697/104493836-4b569c00-55de-11eb-8b04-6063d815aa74.png)

![image](https://user-images.githubusercontent.com/4947697/104493858-56113100-55de-11eb-9dc5-a9df53a1bb0f.png)
