### PR TITLE
'xml.etree.ElementTree.Element' object has no attribute 'getchildren'…

### DIFF
--- a/doorhole.py
+++ b/doorhole.py
@@ -19,7 +19,6 @@ import tempfile
 EXTENSIONS = (
 	'markdown.extensions.extra',
 	'markdown.extensions.sane_lists',
-	'mdx_outline',
 	'mdx_math',
 	PlantUMLMarkdownExtension(
 		server='',#'http://www.plantuml.com/plantuml',


### PR DESCRIPTION
… error with Python 3.9.1

mdx_outline.py is using getchildren at line [154](https://github.com/aleray/mdx_outline/blob/44883ec54d9c3dccd73a781709966c6adb68bbb9/mdx_outline.py#L154)
which has been removed in python 3.9 (https://phabricator.wikimedia.org/T213814).
Doorstop just decided to do the [same](https://github.com/doorstop-dev/doorstop/pull/501/files)

Note: I did try to hack mdx_outline.py with 
```
        for child in node:
```
as per https://github.com/jbarlow83/OCRmyPDF/pull/584/files and error disappear but the rendering is broken (see right side)
![image](https://user-images.githubusercontent.com/4947697/104635303-6098fc80-56aa-11eb-86db-81bdf1cb2cbf.png)
So is safer to simply remove the 'mdx_outline' as Doorstop did...
