### PR TITLE
Refix for d38b270: Fix rows height for the following document tabs

### DIFF
--- a/doorhole.py
+++ b/doorhole.py
@@ -349,10 +349,7 @@ class RequirementManager(QWidget):
 		self.view.horizontalHeader().setStretchLastSection(True)
 		self.view.setWordWrap(True)
 		self.view.resizeColumnsToContents()
-		#self.view.resizeRowsToContents() # this seems to work only for first document tab but is not resizing properly the following tabs
-		header = self.view.verticalHeader()
-		header.setSectionResizeMode(QHeaderView.ResizeToContents)
-		self.view.resizeRowsToContents()
+		self.view.verticalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
 		self.view.setSelectionMode(QAbstractItemView.SingleSelection)
 		self.view.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel);
 		self.view.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel);


### PR DESCRIPTION
(resizeColumnsToContents worked fine only on the first tab)

 - setSectionResizeMode does the job so resizeRowsToContents can be completely removed

Tested on Win10.1909.x64 with Python 3.9.1, Doorstop v2.1.4, PySide2-5.15.2, Markdown 3.3.3.

PS: sorry I don't know how to reopen the previous already merged PR #3 (and in the meantime I also updated the fork with the changes from your upstream, so it might be too complicated to that, this is why I opened this separate PR).
When you mentioned the performance degradation I rechecked the change and noticed that I still left the original **resizeRowsToContents** in d38b270: that is not needed; **setSectionResizeMode** does alone the job properly.
Kindly please double check this too before accepting. Thank you!