### PR TITLE
Fix QMessageBox return variable check

### DIFF
--- a/doorhole.py
+++ b/doorhole.py
@@ -377,7 +377,7 @@ class RequirementSetModel(QAbstractTableModel):
 			qm.setText(str("This will delete the requirement from disk.\nYou will not be able to recover it unless it's versioned.\n\nAre you absolutely sure?"))
 			qm.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
 			ret = qm.exec()
-			if ret == qm.Yes:
+			if ret == QMessageBox.StandardButtons.Yes.value:
 				self.delReq(row)
 	
 	def getItem(self, qidx):


### PR DESCRIPTION
LIne 380 used an older style of QMessageBox() return that is no longer supported in PyQt6